### PR TITLE
Updated dependencies.

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,9 +10,9 @@ Jinja2==2.10.1
 lazy-object-proxy==1.4.0
 MarkupSafe==1.1.1
 mccabe==0.6.1
-pycryptodome==3.3.1
+pycryptodome==3.6.6
 pylint==2.3.1
-python-jose-cryptodome==1.3.2
+python-jose[pycryptodome]==3.1.0
 six==1.12.0
 SQLAlchemy==1.3.3
 typed-ast==1.4.1


### PR DESCRIPTION
-Bumped up pycryptodome (due to vulnerabilities in version 3.3.1)
-Replaced python-jose-cryptodome with the updated version,
python-jose[pycryptodome]